### PR TITLE
feat: track tax codes and read replica for client billing

### DIFF
--- a/migrations/20241101191914-add-more-client-billing.js
+++ b/migrations/20241101191914-add-more-client-billing.js
@@ -1,0 +1,49 @@
+'use strict';
+
+var dbm;
+var type;
+var seed;
+var fs = require('fs');
+var path = require('path');
+var Promise;
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function(options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+  Promise = options.Promise;
+};
+
+exports.up = function(db) {
+  var filePath = path.join(__dirname, 'sqls', '20241101191914-add-more-client-billing-up.sql');
+  return new Promise( function( resolve, reject ) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+      if (err) return reject(err);
+      resolve(data);
+    });
+  })
+  .then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports.down = function(db) {
+  var filePath = path.join(__dirname, 'sqls', '20241101191914-add-more-client-billing-down.sql');
+  return new Promise( function( resolve, reject ) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+      if (err) return reject(err);
+      resolve(data);
+    });
+  })
+  .then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports._meta = {
+  "version": 1
+};

--- a/migrations/sqls/20241101191914-add-more-client-billing-down.sql
+++ b/migrations/sqls/20241101191914-add-more-client-billing-down.sql
@@ -1,0 +1,3 @@
+alter table billing.clients add column taxable boolean not null default false;
+alter table billing.clients drop column tax_name;
+alter table billing.clients drop column has_read_replica;

--- a/migrations/sqls/20241101191914-add-more-client-billing-up.sql
+++ b/migrations/sqls/20241101191914-add-more-client-billing-up.sql
@@ -1,0 +1,3 @@
+alter table billing.clients drop column taxable;
+alter table billing.clients add column tax_name text not null default 'Out of State, no tax payable';
+alter table billing.clients add column has_read_replica boolean not null default false;

--- a/schema-dump.sql
+++ b/schema-dump.sql
@@ -2962,7 +2962,8 @@ CREATE TABLE billing.clients (
     name text NOT NULL,
     access_token text DEFAULT md5((random())::text),
     created_at timestamp without time zone DEFAULT now() NOT NULL,
-    taxable boolean DEFAULT false NOT NULL
+    tax_name text DEFAULT 'Out of State, no tax payable'::text NOT NULL,
+    has_read_replica boolean DEFAULT false NOT NULL
 );
 
 


### PR DESCRIPTION
This is a follow up to #3 to replace the `taxable` bool column with a more precise `tax_name` text column (which should match QBO's tax names). It also adds read replica tracking since more clients are using read replicas now