### PR TITLE
chore(gh): update ci workflow

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     name: 'Hadolint'
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: jbergstroem/hadolint-gh-action@v1
         with:
           error_level: 0
@@ -49,9 +49,9 @@ jobs:
 
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
         with:
           path: node_modules
@@ -78,7 +78,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
@@ -87,7 +87,7 @@ jobs:
 
       # Caching strategy from: https://github.com/docker/build-push-action/blob/master/docs/advanced/cache.md#github-cache
       - name: Cache Docker layers for ${{ matrix.service }}
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: /tmp/.buildx-cache
           key: ${{ runner.os }}-buildx-switchboard-${{ github.sha }}


### PR DESCRIPTION
## Description

This updates our CI pipeline to accomodate 2025 GitHub deprecations, similar to what we've had to do for other repos

## Motivation and Context

Previous versions deprecated

## How Has This Been Tested?

N/A

## Screenshots (if appropriate):

<!-- Tip: you can use a <table> to present screenshots in a better way. -->

## Documentation Changes

<!--- Does your code change the way users interact with Spoke? If so please include proposed documentation changes below -->
<!--- Spoke's user facing documentation is located at https://withtheranks.com/docs/spoke/ -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have included updates for the documentation accordingly.
