### PR TITLE
feat: add routing api

### DIFF
--- a/src/__tests__/routing/api.spec.ts
+++ b/src/__tests__/routing/api.spec.ts
@@ -1,0 +1,178 @@
+import faker from 'faker';
+import { Pool } from 'pg';
+import supertest from 'supertest';
+
+import app from '../../app';
+import config from '../../config';
+import { withClient } from '../../lib/db';
+import { Service } from '../../lib/types';
+import {
+  createPhoneNumber,
+  createProfile,
+  createSendingAccount,
+  createSendingLocation,
+} from '../fixtures';
+
+describe('GET /routing/get-number-for-contact', () => {
+  let pool: Pool;
+  let accessToken: string;
+
+  let toNumberWithMapping: string;
+  let expectedFromNumber: string;
+
+  let profileIdWithMapping: string;
+  let profileIdWithSendingLocation: string;
+  let profileIdNoSendingLocations: string;
+
+  beforeAll(async () => {
+    pool = new Pool({ connectionString: config.databaseUrl });
+
+    const registerResponse = await supertest(app)
+      .post('/admin/register')
+      .set('token', config.adminAccessToken)
+      .send({ name: `routing-api-test-${faker.random.uuid()}` });
+    accessToken = registerResponse.body.access_token;
+
+    await withClient(pool, async (client) => {
+      // Profile with an existing from_number mapping
+      const sa1 = await createSendingAccount(client, {
+        service: Service.Telnyx,
+        triggers: true,
+      });
+      const sl1 = await createSendingLocation(client, {
+        center: '10001',
+        triggers: true,
+        profile: {
+          type: 'create',
+          triggers: true,
+          client: { type: 'create' },
+          sending_account: { type: 'existing', id: sa1.id },
+          profile_service_configuration: {
+            type: 'create',
+            profile_service_configuration_id: `MS${faker.random.alphaNumeric(
+              30
+            )}`,
+          },
+        },
+      });
+      profileIdWithMapping = sl1.profile_id;
+      toNumberWithMapping = faker.phone.phoneNumber('+1##########');
+      expectedFromNumber = faker.phone.phoneNumber('+1##########');
+      await client.query(
+        `INSERT INTO sms.from_number_mappings
+           (profile_id, to_number, from_number, last_used_at, sending_location_id)
+         VALUES ($1, $2, $3, now(), $4)`,
+        [profileIdWithMapping, toNumberWithMapping, expectedFromNumber, sl1.id]
+      );
+
+      // Profile with a sending location and phone number (new-contact happy path)
+      const sa2 = await createSendingAccount(client, {
+        service: Service.Telnyx,
+        triggers: true,
+      });
+      const sl2 = await createSendingLocation(client, {
+        center: '10001',
+        triggers: true,
+        profile: {
+          type: 'create',
+          triggers: true,
+          client: { type: 'create' },
+          sending_account: { type: 'existing', id: sa2.id },
+          profile_service_configuration: {
+            type: 'create',
+            profile_service_configuration_id: `MS${faker.random.alphaNumeric(
+              30
+            )}`,
+          },
+        },
+      });
+      profileIdWithSendingLocation = sl2.profile_id;
+      await createPhoneNumber(client, { sending_location_id: sl2.id });
+
+      // Profile with no sending locations (404 path)
+      const sa3 = await createSendingAccount(client, {
+        service: Service.Telnyx,
+        triggers: true,
+      });
+      const emptyProfile = await createProfile(client, {
+        triggers: true,
+        client: { type: 'create' },
+        sending_account: { type: 'existing', id: sa3.id },
+        profile_service_configuration: {
+          type: 'create',
+          profile_service_configuration_id: `MS${faker.random.alphaNumeric(
+            30
+          )}`,
+        },
+      });
+      profileIdNoSendingLocations = emptyProfile.id;
+    });
+  });
+
+  afterAll(() => pool.end());
+
+  test('returns 401 without an auth token', async () => {
+    const response = await supertest(app)
+      .get('/routing/get-number-for-contact')
+      .query({
+        to_number: '+12125551234',
+        profile_id: faker.random.uuid(),
+        contact_zip_code: '10001',
+      });
+
+    expect(response.status).toBe(401);
+  });
+
+  test('returns 400 when required query params are missing', async () => {
+    const response = await supertest(app)
+      .get('/routing/get-number-for-contact')
+      .set('token', accessToken)
+      .query({ to_number: '+12125551234' });
+
+    expect(response.status).toBe(400);
+    expect(response.body.error).toContain('required');
+  });
+
+  test('returns the existing from_number when a mapping already exists', async () => {
+    const response = await supertest(app)
+      .get('/routing/get-number-for-contact')
+      .set('token', accessToken)
+      .query({
+        to_number: toNumberWithMapping,
+        profile_id: profileIdWithMapping,
+        contact_zip_code: '10001',
+      });
+
+    expect(response.status).toBe(200);
+    expect(response.body.from_number).toBe(expectedFromNumber);
+  });
+
+  test('returns 404 when no sending location exists for the profile', async () => {
+    const response = await supertest(app)
+      .get('/routing/get-number-for-contact')
+      .set('token', accessToken)
+      .query({
+        to_number: faker.phone.phoneNumber('+1##########'),
+        profile_id: profileIdNoSendingLocations,
+        contact_zip_code: '10001',
+      });
+
+    expect(response.status).toBe(404);
+    expect(response.body.error).toBe('No sending location found for contact');
+  });
+
+  test('returns a from_number for a new contact via sending location', async () => {
+    const response = await supertest(app)
+      .get('/routing/get-number-for-contact')
+      .set('token', accessToken)
+      .query({
+        to_number: faker.phone.phoneNumber('+1##########'),
+        profile_id: profileIdWithSendingLocation,
+        contact_zip_code: '10001',
+      });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toHaveProperty('from_number');
+    expect(typeof response.body.from_number).toBe('string');
+  });
+});

--- a/src/__tests__/routing/api.spec.ts
+++ b/src/__tests__/routing/api.spec.ts
@@ -175,4 +175,18 @@ describe('GET /routing/get-number-for-contact', () => {
     expect(response.body).toHaveProperty('from_number');
     expect(typeof response.body.from_number).toBe('string');
   });
+
+  test('returns a from_number when contact_zip_code is omitted, using area code from to_number', async () => {
+    const response = await supertest(app)
+      .get('/routing/get-number-for-contact')
+      .set('token', accessToken)
+      .query({
+        to_number: faker.phone.phoneNumber('+1212#######'),
+        profile_id: profileIdWithSendingLocation,
+      });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toHaveProperty('from_number');
+    expect(typeof response.body.from_number).toBe('string');
+  });
 });

--- a/src/apis/routing.ts
+++ b/src/apis/routing.ts
@@ -29,11 +29,7 @@ app.get('/get-number-for-contact', auth.client, async (req, res) => {
     });
   }
 
-  const {
-    to_number,
-    profile_id,
-    contact_zip_code,
-  } = parsed.data;
+  const { to_number, profile_id, contact_zip_code } = parsed.data;
   const client = await pgPool.connect();
 
   try {

--- a/src/apis/routing.ts
+++ b/src/apis/routing.ts
@@ -16,7 +16,7 @@ const app = express();
 const GetNumberForContactQuery = z.object({
   to_number: z.string(),
   profile_id: z.string(),
-  contact_zip_code: z.string(),
+  contact_zip_code: z.string().optional(),
 });
 
 app.get('/get-number-for-contact', auth.client, async (req, res) => {
@@ -25,14 +25,14 @@ app.get('/get-number-for-contact', auth.client, async (req, res) => {
 
   if (!parsed.success) {
     return res.status(400).json({
-      error: 'to_number, profile_id, and contact_zip_code are required',
+      error: 'to_number and profile_id are required',
     });
   }
 
   const {
     to_number,
     profile_id,
-    contact_zip_code: contactZipCode,
+    contact_zip_code,
   } = parsed.data;
   const client = await pgPool.connect();
 
@@ -46,6 +46,15 @@ app.get('/get-number-for-contact', auth.client, async (req, res) => {
       return res.json({
         from_number: prevMapping.from_number,
       });
+    }
+
+    let contactZipCode = contact_zip_code;
+    if (!contactZipCode) {
+      const zipResult = await client.query<{ zip: string }>(
+        'select sms.map_area_code_to_zip_code(sms.extract_area_code($1)) as zip',
+        [to_number]
+      );
+      contactZipCode = zipResult.rows[0].zip;
     }
 
     const env = { redis: getRedis(), pg: client };

--- a/src/apis/routing.ts
+++ b/src/apis/routing.ts
@@ -1,0 +1,83 @@
+import express from 'express';
+import { z } from 'zod';
+
+import { pgPool } from '../db';
+import { auth, ClientAuthenticatedRequest } from '../lib/auth';
+import {
+  getFromNumberMapping,
+  getNumberForSendingLocation,
+} from '../lib/process-message';
+import { chooseSendingLocationForContact, getRedis } from '../lib/redis';
+import { errToObj, logger } from '../logger';
+
+const app = express();
+
+// tslint:disable-next-line variable-name
+const GetNumberForContactQuery = z.object({
+  to_number: z.string(),
+  profile_id: z.string(),
+  contact_zip_code: z.string(),
+});
+
+app.get('/get-number-for-contact', auth.client, async (req, res) => {
+  const authnReq = req as ClientAuthenticatedRequest;
+  const parsed = GetNumberForContactQuery.safeParse(authnReq.query);
+
+  if (!parsed.success) {
+    return res
+      .status(400)
+      .json({
+        error: 'to_number, profile_id, and contact_zip_code are required',
+      });
+  }
+
+  const {
+    to_number,
+    profile_id,
+    contact_zip_code: contactZipCode,
+  } = parsed.data;
+  const client = await pgPool.connect();
+
+  try {
+    const prevMapping = await getFromNumberMapping(client, {
+      toNumber: to_number,
+      profileId: profile_id,
+    });
+
+    if (prevMapping !== undefined) {
+      return res.json({
+        from_number: prevMapping.from_number,
+      });
+    }
+
+    const env = { redis: getRedis(), pg: client };
+    const sendingLocationId = await chooseSendingLocationForContact(
+      env,
+      profile_id,
+      { contactZipCode }
+    );
+
+    if (sendingLocationId === undefined) {
+      return res
+        .status(404)
+        .json({ error: 'No sending location found for contact' });
+    }
+
+    const fromNumber = await getNumberForSendingLocation(
+      client,
+      sendingLocationId
+    );
+
+    return res.json({
+      from_number: fromNumber,
+    });
+  } catch (err) {
+    logger.error('error in get-number-for-contact: ', errToObj(err));
+    const errMessage = err instanceof Error ? err.message : 'unknown';
+    return res.status(500).json({ error: errMessage });
+  } finally {
+    client.release();
+  }
+});
+
+export default app;

--- a/src/apis/routing.ts
+++ b/src/apis/routing.ts
@@ -24,11 +24,9 @@ app.get('/get-number-for-contact', auth.client, async (req, res) => {
   const parsed = GetNumberForContactQuery.safeParse(authnReq.query);
 
   if (!parsed.success) {
-    return res
-      .status(400)
-      .json({
-        error: 'to_number, profile_id, and contact_zip_code are required',
-      });
+    return res.status(400).json({
+      error: 'to_number, profile_id, and contact_zip_code are required',
+    });
   }
 
   const {

--- a/src/app.ts
+++ b/src/app.ts
@@ -12,6 +12,7 @@ import lookup from './apis/graphql/lookup';
 import sms from './apis/graphql/sms';
 import lookupJson from './apis/lookup-json';
 import replies from './apis/replies';
+import routing from './apis/routing';
 import { expressErrorLogger, expressLogger, statsd } from './logger';
 
 const app = express();
@@ -52,6 +53,11 @@ app.get('/', (_req, res) => res.sendStatus(200));
  * For simple single use lookups
  */
 app.use('/lookup/json', lookupJson);
+
+/**
+ * For phone number routing (without sending a text)
+ */
+app.use('/routing', routing);
 
 /**
  * Postgraphile endpoints


### PR DESCRIPTION
This allows a client to fetch the from number that Switchboard would use to text a contact, without sending a text. Currently intended to support phone calls placed from Spoke, reusing texting numbers.