### PR TITLE
feat(routing): add call number pool

### DIFF
--- a/migrations/20260610000000-calling-routing.js
+++ b/migrations/20260610000000-calling-routing.js
@@ -1,0 +1,49 @@
+'use strict';
+
+var dbm;
+var type;
+var seed;
+var fs = require('fs');
+var path = require('path');
+var Promise;
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function(options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+  Promise = options.Promise;
+};
+
+exports.up = function(db) {
+  var filePath = path.join(__dirname, 'sqls', '20260610000000-calling-routing-up.sql');
+  return new Promise( function( resolve, reject ) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+      if (err) return reject(err);
+      resolve(data);
+    });
+  })
+  .then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports.down = function(db) {
+  var filePath = path.join(__dirname, 'sqls', '20260610000000-calling-routing-down.sql');
+  return new Promise( function( resolve, reject ) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+      if (err) return reject(err);
+      resolve(data);
+    });
+  })
+  .then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports._meta = {
+  "version": 1
+};

--- a/migrations/sqls/20260610000000-calling-routing-down.sql
+++ b/migrations/sqls/20260610000000-calling-routing-down.sql
@@ -1,0 +1,134 @@
+-- Restore the previous version of the fulfill trigger (without for_calling branching)
+CREATE OR REPLACE FUNCTION sms.tg__phone_number_requests__fulfill() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+declare
+  v_throughput_interval interval;
+  v_throughput_limit integer;
+  v_sending_account_id uuid;
+  v_capacity integer;
+  v_purchasing_strategy sms.number_purchasing_strategy;
+begin
+  -- Create the phone number record
+  insert into sms.all_phone_numbers (
+    sending_location_id,
+    phone_number
+  )
+  values (
+    NEW.sending_location_id,
+    NEW.phone_number
+  );
+
+  select sending_account_id, throughput_interval, throughput_limit
+  from sms.profiles profiles
+  join sms.sending_locations locations on locations.profile_id = profiles.id
+  where locations.id = NEW.sending_location_id
+  into v_sending_account_id, v_throughput_interval, v_throughput_limit;
+
+  -- Update area code capacities
+  with update_result as (
+    update sms.area_code_capacities
+    set capacity = capacity - 1
+    where
+      area_code = NEW.area_code
+      and sending_account_id = v_sending_account_id
+    returning capacity
+  )
+  select capacity
+  from update_result
+  into v_capacity;
+
+  if ((v_capacity is not null) and (mod(v_capacity, 5) = 0)) then
+    select purchasing_strategy
+    from sms.sending_locations
+    where id = NEW.sending_location_id
+    into v_purchasing_strategy;
+
+    if v_purchasing_strategy = 'exact-area-codes' then
+      perform sms.refresh_one_area_code_capacity(NEW.area_code, v_sending_account_id);
+    elsif v_purchasing_strategy = 'same-state-by-distance' then
+      perform sms.queue_find_suitable_area_codes_refresh(NEW.sending_location_id);
+    else
+      raise exception 'Unknown purchasing strategy: %', v_purchasing_strategy;
+    end if;
+  end if;
+
+  with
+    deleted_afn as (
+      delete from sms.outbound_messages_awaiting_from_number
+      where pending_number_request_id = NEW.id
+      returning *
+    ),
+    interval_waits as (
+      select
+        id,
+        to_number,
+        original_created_at,
+        sum(estimated_segments) over (partition by 1 order by original_created_at) as nth_segment
+      from (
+        select id, to_number, estimated_segments, original_created_at
+        from deleted_afn
+      ) all_messages
+    )
+    insert into sms.outbound_messages_routing
+      (
+        id,
+        to_number,
+        estimated_segments,
+        decision_stage,
+        sending_location_id,
+        pending_number_request_id,
+        processed_at,
+        original_created_at,
+        from_number,
+        stage,
+        first_from_to_pair_of_day,
+        send_after,
+        profile_id
+      )
+    select
+        afn.id,
+        afn.to_number,
+        estimated_segments,
+        decision_stage,
+        sending_location_id,
+        pending_number_request_id,
+        processed_at,
+        afn.original_created_at,
+        NEW.phone_number as from_number,
+        'queued' as stage,
+        true as first_from_to_pair_of_day,
+        now() + ((interval_waits.nth_segment / v_throughput_limit) * v_throughput_interval) as send_after,
+        profile_id
+    from deleted_afn afn
+    join interval_waits on interval_waits.id = afn.id;
+
+  perform graphile_worker.add_job(
+    identifier => 'resolve-messages-awaiting-from-number'::text,
+    payload => to_json(NEW),
+    run_at => clock_timestamp()::timestamp + '10 second'::interval,
+    max_attempts => 5
+  );
+
+  perform graphile_worker.add_job(
+    identifier => 'resolve-messages-awaiting-from-number'::text,
+    payload => to_json(NEW),
+    run_at => clock_timestamp()::timestamp + '1 minute'::interval,
+    max_attempts => 5
+  );
+
+  perform graphile_worker.add_job(
+    identifier => 'resolve-messages-awaiting-from-number'::text,
+    payload => to_json(NEW),
+    run_at => clock_timestamp()::timestamp + '5 minute'::interval,
+    max_attempts => 5
+  );
+
+  return NEW;
+end;
+$$;
+
+drop table sms.outbound_calls;
+drop table sms.calling_phone_numbers;
+alter table sms.phone_number_requests drop column for_calling;
+alter table sms.profiles drop column daily_calling_limit;

--- a/migrations/sqls/20260610000000-calling-routing-up.sql
+++ b/migrations/sqls/20260610000000-calling-routing-up.sql
@@ -1,0 +1,153 @@
+alter table sms.profiles add column daily_calling_limit integer;
+
+alter table sms.phone_number_requests add column for_calling boolean not null default false;
+
+-- Separate pool of numbers reserved for outbound calling only (not used for texting)
+create table sms.calling_phone_numbers (
+  phone_number phone_number primary key,
+  sending_location_id uuid not null references sms.sending_locations(id),
+  created_at timestamp not null default now(),
+  cordoned_at timestamp,
+  released_at timestamp
+);
+
+comment on table sms.calling_phone_numbers is E'@omit';
+
+-- Tracks each call routed through the system for daily-limit accounting
+create table sms.outbound_calls (
+  id uuid not null default uuid_generate_v1mc(),
+  from_number phone_number not null,
+  sending_location_id uuid not null references sms.sending_locations(id),
+  created_at timestamp not null default now()
+);
+
+select create_hypertable(
+  'sms.outbound_calls',
+  'created_at',
+  chunk_time_interval => interval '1 day'
+);
+
+alter table sms.outbound_calls add primary key (created_at, id);
+
+create index outbound_calls_sending_location_date_idx
+  on sms.outbound_calls (sending_location_id, created_at desc);
+
+comment on table sms.outbound_calls is E'@omit';
+
+-- When a phone_number_request with for_calling=true is fulfilled, insert into
+-- calling_phone_numbers instead of all_phone_numbers and skip SMS message resolution.
+CREATE OR REPLACE FUNCTION sms.tg__phone_number_requests__fulfill() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+declare
+  v_throughput_interval interval;
+  v_throughput_limit integer;
+  v_sending_account_id uuid;
+  v_capacity integer;
+  v_purchasing_strategy sms.number_purchasing_strategy;
+begin
+  if NEW.for_calling then
+    insert into sms.calling_phone_numbers (sending_location_id, phone_number)
+    values (NEW.sending_location_id, NEW.phone_number);
+  else
+    insert into sms.phone_numbers (sending_location_id, phone_number)
+    values (NEW.sending_location_id, NEW.phone_number);
+  end if;
+
+  select sending_account_id, throughput_interval, throughput_limit
+  from sms.profiles profiles
+  join sms.sending_locations locations on locations.profile_id = profiles.id
+  where locations.id = NEW.sending_location_id
+  into v_sending_account_id, v_throughput_interval, v_throughput_limit;
+
+  -- Update area code capacities
+  with update_result as (
+    update sms.area_code_capacities
+    set capacity = capacity - 1
+    where
+      area_code = NEW.area_code
+      and sending_account_id = v_sending_account_id
+    returning capacity
+  )
+  select capacity
+  from update_result
+  into v_capacity;
+
+  if ((v_capacity is not null) and (mod(v_capacity, 5) = 0)) then
+    select purchasing_strategy
+    from sms.sending_locations
+    where id = NEW.sending_location_id
+    into v_purchasing_strategy;
+
+    if v_purchasing_strategy = 'exact-area-codes' then
+      perform sms.refresh_one_area_code_capacity(NEW.area_code, v_sending_account_id);
+    elsif v_purchasing_strategy = 'same-state-by-distance' then
+      perform sms.queue_find_suitable_area_codes_refresh(NEW.sending_location_id);
+    else
+      raise exception 'Unknown purchasing strategy: %', v_purchasing_strategy;
+    end if;
+  end if;
+
+  if not NEW.for_calling then
+  -- Process queued outbound messages
+    perform graphile_worker.add_job(
+      identifier => 'resolve-messages-awaiting-from-number'::text,
+      payload => to_json(NEW),
+      run_at => clock_timestamp()::timestamp + '10 second'::interval,
+      max_attempts => 5
+    );
+
+    perform graphile_worker.add_job(
+      identifier => 'resolve-messages-awaiting-from-number'::text,
+      payload => to_json(NEW),
+      run_at => clock_timestamp()::timestamp + '1 minute'::interval,
+      max_attempts => 5
+    );
+
+    perform graphile_worker.add_job(
+      identifier => 'resolve-messages-awaiting-from-number'::text,
+      payload => to_json(NEW),
+      run_at => clock_timestamp()::timestamp + '5 minute'::interval,
+      max_attempts => 5
+    );
+  end if;
+
+  return NEW;
+end;
+$$;
+
+-- Shared helper: returns all numbers under the daily limit with their priority and call count.
+-- Priority 1 = texting numbers, Priority 2 = calling-only numbers.
+create or replace function sms.get_available_calling_numbers(
+  v_sending_location_id uuid,
+  v_daily_calling_limit integer
+) returns table(phone_number phone_number, call_count bigint, priority integer) as $$
+  with daily_counts as (
+    select from_number, count(*) as call_count
+    from sms.outbound_calls
+    where sending_location_id = $1
+      and created_at > date_trunc('day', now() at time zone 'America/Los_Angeles') at time zone 'UTC'
+    group by from_number
+  ),
+  available_texting as (
+    select pn.phone_number, coalesce(dc.call_count, 0) as call_count, 1 as priority
+    from sms.phone_numbers pn
+    left join daily_counts dc on pn.phone_number = dc.from_number
+    where pn.sending_location_id = $1
+      and pn.cordoned_at is null
+      and coalesce(dc.call_count, 0) < $2
+  ),
+  available_calling as (
+    select cpn.phone_number, coalesce(dc.call_count, 0) as call_count, 2 as priority
+    from sms.calling_phone_numbers cpn
+    left join daily_counts dc on cpn.phone_number = dc.from_number
+    where cpn.sending_location_id = $1
+      and cpn.released_at is null
+      and cpn.cordoned_at is null
+      and coalesce(dc.call_count, 0) < $2
+  )
+  select * from available_texting
+  union all
+  select * from available_calling
+$$ language sql stable;
+

--- a/schema-dump.sql
+++ b/schema-dump.sql
@@ -1752,6 +1752,45 @@ COMMENT ON FUNCTION sms.extract_area_code(phone_number public.phone_number) IS '
 
 
 --
+-- Name: get_available_calling_numbers(uuid, integer); Type: FUNCTION; Schema: sms; Owner: postgres
+--
+
+CREATE FUNCTION sms.get_available_calling_numbers(v_sending_location_id uuid, v_daily_calling_limit integer) RETURNS TABLE(phone_number public.phone_number, call_count bigint, priority integer)
+    LANGUAGE sql STABLE
+    AS $_$
+  with daily_counts as (
+    select from_number, count(*) as call_count
+    from sms.outbound_calls
+    where sending_location_id = $1
+      and created_at > date_trunc('day', now() at time zone 'America/Los_Angeles') at time zone 'UTC'
+    group by from_number
+  ),
+  available_texting as (
+    select pn.phone_number, coalesce(dc.call_count, 0) as call_count, 1 as priority
+    from sms.phone_numbers pn
+    left join daily_counts dc on pn.phone_number = dc.from_number
+    where pn.sending_location_id = $1
+      and pn.cordoned_at is null
+      and coalesce(dc.call_count, 0) < $2
+  ),
+  available_calling as (
+    select cpn.phone_number, coalesce(dc.call_count, 0) as call_count, 2 as priority
+    from sms.calling_phone_numbers cpn
+    left join daily_counts dc on cpn.phone_number = dc.from_number
+    where cpn.sending_location_id = $1
+      and cpn.released_at is null
+      and cpn.cordoned_at is null
+      and coalesce(dc.call_count, 0) < $2
+  )
+  select * from available_texting
+  union all
+  select * from available_calling
+$_$;
+
+
+ALTER FUNCTION sms.get_available_calling_numbers(v_sending_location_id uuid, v_daily_calling_limit integer) OWNER TO postgres;
+
+--
 -- Name: increment_commitment_bucket_if_unique(); Type: FUNCTION; Schema: sms; Owner: postgres
 --
 
@@ -2521,15 +2560,13 @@ declare
   v_capacity integer;
   v_purchasing_strategy sms.number_purchasing_strategy;
 begin
-  -- Create the phone number record
-  insert into sms.phone_numbers (
-    sending_location_id,
-    phone_number
-  )
-  values (
-    NEW.sending_location_id,
-    NEW.phone_number
-  );
+  if NEW.for_calling then
+    insert into sms.calling_phone_numbers (sending_location_id, phone_number)
+    values (NEW.sending_location_id, NEW.phone_number);
+  else
+    insert into sms.phone_numbers (sending_location_id, phone_number)
+    values (NEW.sending_location_id, NEW.phone_number);
+  end if;
 
   select sending_account_id, throughput_interval, throughput_limit
   from sms.profiles profiles
@@ -2565,27 +2602,29 @@ begin
     end if;
   end if;
 
+  if not NEW.for_calling then
   -- Process queued outbound messages
-  perform graphile_worker.add_job(
-    identifier => 'resolve-messages-awaiting-from-number'::text,
-    payload => to_json(NEW),
-    run_at => clock_timestamp()::timestamp + '10 second'::interval,
-    max_attempts => 5
-  );
+    perform graphile_worker.add_job(
+      identifier => 'resolve-messages-awaiting-from-number'::text,
+      payload => to_json(NEW),
+      run_at => clock_timestamp()::timestamp + '10 second'::interval,
+      max_attempts => 5
+    );
 
-  perform graphile_worker.add_job(
-    identifier => 'resolve-messages-awaiting-from-number'::text,
-    payload => to_json(NEW),
-    run_at => clock_timestamp()::timestamp + '1 minute'::interval,
-    max_attempts => 5
-  );
+    perform graphile_worker.add_job(
+      identifier => 'resolve-messages-awaiting-from-number'::text,
+      payload => to_json(NEW),
+      run_at => clock_timestamp()::timestamp + '1 minute'::interval,
+      max_attempts => 5
+    );
 
-  perform graphile_worker.add_job(
-    identifier => 'resolve-messages-awaiting-from-number'::text,
-    payload => to_json(NEW),
-    run_at => clock_timestamp()::timestamp + '5 minute'::interval,
-    max_attempts => 5
-  );
+    perform graphile_worker.add_job(
+      identifier => 'resolve-messages-awaiting-from-number'::text,
+      payload => to_json(NEW),
+      run_at => clock_timestamp()::timestamp + '5 minute'::interval,
+      max_attempts => 5
+    );
+  end if;
 
   return NEW;
 end;
@@ -3065,6 +3104,7 @@ CREATE TABLE sms.profiles (
     toll_free_use_case_id uuid,
     profile_service_configuration_id uuid,
     tendlc_campaign_id uuid,
+    daily_calling_limit integer,
     CONSTRAINT valid_10dlc_channel CHECK (((channel <> '10dlc'::sms.traffic_channel) OR (tendlc_campaign_id IS NOT NULL))),
     CONSTRAINT valid_toll_free_channel CHECK (((channel <> 'toll-free'::sms.traffic_channel) OR (toll_free_use_case_id IS NOT NULL)))
 );
@@ -3489,6 +3529,28 @@ COMMENT ON TABLE sms.area_code_capacities IS '@omit';
 
 
 --
+-- Name: calling_phone_numbers; Type: TABLE; Schema: sms; Owner: postgres
+--
+
+CREATE TABLE sms.calling_phone_numbers (
+    phone_number public.phone_number NOT NULL,
+    sending_location_id uuid NOT NULL,
+    created_at timestamp without time zone DEFAULT now() NOT NULL,
+    cordoned_at timestamp without time zone,
+    released_at timestamp without time zone
+);
+
+
+ALTER TABLE sms.calling_phone_numbers OWNER TO postgres;
+
+--
+-- Name: TABLE calling_phone_numbers; Type: COMMENT; Schema: sms; Owner: postgres
+--
+
+COMMENT ON TABLE sms.calling_phone_numbers IS '@omit';
+
+
+--
 -- Name: delivery_report_forward_attempts; Type: TABLE; Schema: sms; Owner: postgres
 --
 
@@ -3585,6 +3647,27 @@ ALTER TABLE sms.inbound_message_forward_attempts OWNER TO postgres;
 --
 
 COMMENT ON TABLE sms.inbound_message_forward_attempts IS '@omit';
+
+
+--
+-- Name: outbound_calls; Type: TABLE; Schema: sms; Owner: postgres
+--
+
+CREATE TABLE sms.outbound_calls (
+    id uuid DEFAULT public.uuid_generate_v1mc() NOT NULL,
+    from_number public.phone_number NOT NULL,
+    sending_location_id uuid NOT NULL,
+    created_at timestamp without time zone DEFAULT now() NOT NULL
+);
+
+
+ALTER TABLE sms.outbound_calls OWNER TO postgres;
+
+--
+-- Name: TABLE outbound_calls; Type: COMMENT; Schema: sms; Owner: postgres
+--
+
+COMMENT ON TABLE sms.outbound_calls IS '@omit';
 
 
 --
@@ -3688,7 +3771,8 @@ CREATE TABLE sms.phone_number_requests (
     service_order_completed_at timestamp with time zone,
     service_profile_associated_at timestamp with time zone,
     service_10dlc_campaign_associated_at timestamp with time zone,
-    tendlc_campaign_id uuid
+    tendlc_campaign_id uuid,
+    for_calling boolean DEFAULT false NOT NULL
 );
 
 
@@ -4232,6 +4316,14 @@ ALTER TABLE ONLY public.migrations
 
 
 --
+-- Name: calling_phone_numbers calling_phone_numbers_pkey; Type: CONSTRAINT; Schema: sms; Owner: postgres
+--
+
+ALTER TABLE ONLY sms.calling_phone_numbers
+    ADD CONSTRAINT calling_phone_numbers_pkey PRIMARY KEY (phone_number);
+
+
+--
 -- Name: tendlc_campaign_mno_metadata campaign_mno_metadata_unique_campaign_mno; Type: CONSTRAINT; Schema: sms; Owner: postgres
 --
 
@@ -4253,6 +4345,14 @@ ALTER TABLE ONLY sms.fresh_phone_commitments
 
 ALTER TABLE ONLY sms.inbound_messages
     ADD CONSTRAINT inbound_messages_pkey PRIMARY KEY (received_at, id);
+
+
+--
+-- Name: outbound_calls outbound_calls_pkey; Type: CONSTRAINT; Schema: sms; Owner: postgres
+--
+
+ALTER TABLE ONLY sms.outbound_calls
+    ADD CONSTRAINT outbound_calls_pkey PRIMARY KEY (created_at, id);
 
 
 --
@@ -4534,6 +4634,20 @@ CREATE INDEX inbound_messages_received_at_idx ON sms.inbound_messages USING btre
 --
 
 CREATE INDEX inbound_messages_sending_location_id_idx ON sms.inbound_messages USING btree (sending_location_id);
+
+
+--
+-- Name: outbound_calls_created_at_idx; Type: INDEX; Schema: sms; Owner: postgres
+--
+
+CREATE INDEX outbound_calls_created_at_idx ON sms.outbound_calls USING btree (created_at DESC);
+
+
+--
+-- Name: outbound_calls_sending_location_date_idx; Type: INDEX; Schema: sms; Owner: postgres
+--
+
+CREATE INDEX outbound_calls_sending_location_date_idx ON sms.outbound_calls USING btree (sending_location_id, created_at DESC);
 
 
 --
@@ -4978,6 +5092,13 @@ CREATE TRIGGER ts_insert_blocker BEFORE INSERT ON sms.inbound_messages FOR EACH 
 
 
 --
+-- Name: outbound_calls ts_insert_blocker; Type: TRIGGER; Schema: sms; Owner: postgres
+--
+
+CREATE TRIGGER ts_insert_blocker BEFORE INSERT ON sms.outbound_calls FOR EACH ROW EXECUTE FUNCTION _timescaledb_internal.insert_blocker();
+
+
+--
 -- Name: outbound_messages ts_insert_blocker; Type: TRIGGER; Schema: sms; Owner: postgres
 --
 
@@ -5063,6 +5184,14 @@ ALTER TABLE ONLY sms.area_code_capacities
 
 
 --
+-- Name: calling_phone_numbers calling_phone_numbers_sending_location_id_fkey; Type: FK CONSTRAINT; Schema: sms; Owner: postgres
+--
+
+ALTER TABLE ONLY sms.calling_phone_numbers
+    ADD CONSTRAINT calling_phone_numbers_sending_location_id_fkey FOREIGN KEY (sending_location_id) REFERENCES sms.sending_locations(id);
+
+
+--
 -- Name: fresh_phone_commitments fresh_phone_commitments_sending_location_id_fkey; Type: FK CONSTRAINT; Schema: sms; Owner: postgres
 --
 
@@ -5084,6 +5213,14 @@ ALTER TABLE ONLY sms.from_number_mappings
 
 ALTER TABLE ONLY sms.inbound_messages
     ADD CONSTRAINT inbound_messages_sending_location_id_fkey FOREIGN KEY (sending_location_id) REFERENCES sms.sending_locations(id);
+
+
+--
+-- Name: outbound_calls outbound_calls_sending_location_id_fkey; Type: FK CONSTRAINT; Schema: sms; Owner: postgres
+--
+
+ALTER TABLE ONLY sms.outbound_calls
+    ADD CONSTRAINT outbound_calls_sending_location_id_fkey FOREIGN KEY (sending_location_id) REFERENCES sms.sending_locations(id);
 
 
 --

--- a/src/__tests__/numbers/sendMessage.spec.ts
+++ b/src/__tests__/numbers/sendMessage.spec.ts
@@ -1014,7 +1014,8 @@ describe('sms.tg__phone_number_requests__fulfill', () => {
           }
 
           const { rows: pendingNumberRequests } = await client.query(
-            'select * from sms.phone_number_requests;'
+            'select * from sms.phone_number_requests where for_calling = false and sending_location_id = $1',
+            [sendingLocationId]
           );
 
           expect(pendingNumberRequests).toHaveLength(1);

--- a/src/__tests__/routing/api.spec.ts
+++ b/src/__tests__/routing/api.spec.ts
@@ -34,6 +34,12 @@ describe('GET /routing/get-number-for-contact', () => {
     accessToken = registerResponse.body.access_token;
 
     await withClient(pool, async (client) => {
+      const setCallingLimit = (profileId: string) =>
+        client.query(
+          `UPDATE sms.profiles SET daily_calling_limit = 50 WHERE id = $1`,
+          [profileId]
+        );
+
       // Profile with an existing from_number mapping
       const sa1 = await createSendingAccount(client, {
         service: Service.Telnyx,
@@ -56,6 +62,7 @@ describe('GET /routing/get-number-for-contact', () => {
         },
       });
       profileIdWithMapping = sl1.profile_id;
+      await setCallingLimit(profileIdWithMapping);
       toNumberWithMapping = faker.phone.phoneNumber('+1##########');
       expectedFromNumber = faker.phone.phoneNumber('+1##########');
       await client.query(
@@ -87,6 +94,7 @@ describe('GET /routing/get-number-for-contact', () => {
         },
       });
       profileIdWithSendingLocation = sl2.profile_id;
+      await setCallingLimit(profileIdWithSendingLocation);
       await createPhoneNumber(client, { sending_location_id: sl2.id });
 
       // Profile with no sending locations (404 path)
@@ -106,6 +114,7 @@ describe('GET /routing/get-number-for-contact', () => {
         },
       });
       profileIdNoSendingLocations = emptyProfile.id;
+      await setCallingLimit(profileIdNoSendingLocations);
     });
   });
 

--- a/src/apis/routing.ts
+++ b/src/apis/routing.ts
@@ -79,9 +79,9 @@ app.get('/get-number-for-contact', auth.client, async (req, res) => {
           [profile_id, to_number]
         );
         await client.query(
-          `insert into sms.outbound_calls (from_number, sending_location_id, profile_id)
-           values ($1, $2, $3)`,
-          [prevMapping.from_number, prevMapping.sending_location_id, profile_id]
+          `insert into sms.outbound_calls (from_number, sending_location_id)
+           values ($1, $2)`,
+          [prevMapping.from_number, prevMapping.sending_location_id]
         );
         return res.json({ from_number: prevMapping.from_number });
       }
@@ -126,9 +126,9 @@ app.get('/get-number-for-contact', auth.client, async (req, res) => {
     // Record the call (no from_number_mappings insert — calling numbers must not be
     // used as from-numbers for SMS)
     await client.query(
-      `insert into sms.outbound_calls (from_number, sending_location_id, profile_id)
-       values ($1, $2, $3)`,
-      [fromNumber, sendingLocationId, profile_id]
+      `insert into sms.outbound_calls (from_number, sending_location_id)
+       values ($1, $2)`,
+      [fromNumber, sendingLocationId]
     );
 
     const availableCount = await countAvailableCallingNumbers(

--- a/src/apis/routing.ts
+++ b/src/apis/routing.ts
@@ -1,14 +1,19 @@
 import express from 'express';
 import { z } from 'zod';
 
+import config from '../config';
 import { pgPool } from '../db';
 import { auth, ClientAuthenticatedRequest } from '../lib/auth';
 import {
-  getFromNumberMapping,
-  getNumberForSendingLocation,
-} from '../lib/process-message';
+  countAvailableCallingNumbers,
+  getCallingNumberForSendingLocation,
+  requestCallingNumber,
+} from '../lib/process-call';
+import { getFromNumberMapping } from '../lib/process-message';
 import { chooseSendingLocationForContact, getRedis } from '../lib/redis';
 import { errToObj, logger } from '../logger';
+
+const { sendingLocationMinCallingNumbers } = config;
 
 const app = express();
 
@@ -33,15 +38,54 @@ app.get('/get-number-for-contact', auth.client, async (req, res) => {
   const client = await pgPool.connect();
 
   try {
+    const {
+      rows: [profile],
+    } = await client.query<{ daily_calling_limit: number | null }>(
+      'select daily_calling_limit from sms.profiles where id = $1',
+      [profile_id]
+    );
+
+    const { daily_calling_limit } = profile;
+
+    if (!profile || daily_calling_limit === null) {
+      return res.status(400).json({
+        error:
+          'Profile does not have calling configured (daily_calling_limit not set)',
+      });
+    }
+
+    // Check for an existing sticky mapping for this contact
     const prevMapping = await getFromNumberMapping(client, {
       toNumber: to_number,
       profileId: profile_id,
     });
 
     if (prevMapping !== undefined) {
-      return res.json({
-        from_number: prevMapping.from_number,
-      });
+      const {
+        rows: [{ count }],
+      } = await client.query<{ count: string }>(
+        `select count(*) from sms.outbound_calls
+         where from_number = $1
+           and created_at > date_trunc('day', now() at time zone 'America/Los_Angeles') at time zone 'UTC'`,
+        [prevMapping.from_number]
+      );
+      const todayCallCount = parseInt(count, 10);
+
+      if (todayCallCount < daily_calling_limit) {
+        await client.query(
+          `update sms.from_number_mappings
+           set last_used_at = now()
+           where profile_id = $1 and to_number = $2 and invalidated_at is null`,
+          [profile_id, to_number]
+        );
+        await client.query(
+          `insert into sms.outbound_calls (from_number, sending_location_id, profile_id)
+           values ($1, $2, $3)`,
+          [prevMapping.from_number, prevMapping.sending_location_id, profile_id]
+        );
+        return res.json({ from_number: prevMapping.from_number });
+      }
+      // Mapped number has hit its daily limit — fall through to fresh selection
     }
 
     let contactZipCode = contact_zip_code;
@@ -66,14 +110,38 @@ app.get('/get-number-for-contact', auth.client, async (req, res) => {
         .json({ error: 'No sending location found for contact' });
     }
 
-    const fromNumber = await getNumberForSendingLocation(
+    const fromNumber = await getCallingNumberForSendingLocation(
       client,
-      sendingLocationId
+      sendingLocationId,
+      daily_calling_limit
     );
 
-    return res.json({
-      from_number: fromNumber,
-    });
+    if (fromNumber === null) {
+      await requestCallingNumber(client, sendingLocationId);
+      return res.status(503).json({
+        error: 'No calling numbers available, a purchase is being initiated',
+      });
+    }
+
+    // Record the call (no from_number_mappings insert — calling numbers must not be
+    // used as from-numbers for SMS)
+    await client.query(
+      `insert into sms.outbound_calls (from_number, sending_location_id, profile_id)
+       values ($1, $2, $3)`,
+      [fromNumber, sendingLocationId, profile_id]
+    );
+
+    const availableCount = await countAvailableCallingNumbers(
+      client,
+      sendingLocationId,
+      daily_calling_limit
+    );
+
+    if (availableCount <= sendingLocationMinCallingNumbers) {
+      await requestCallingNumber(client, sendingLocationId);
+    }
+
+    return res.json({ from_number: fromNumber });
   } catch (err) {
     logger.error('error in get-number-for-contact: ', errToObj(err));
     const errMessage = err instanceof Error ? err.message : 'unknown';

--- a/src/config.ts
+++ b/src/config.ts
@@ -21,6 +21,7 @@ interface AppConfig extends CleanEnv {
   mode: string;
   workerConcurrency: number;
   minSuitableNumbers: number;
+  sendingLocationMinCallingNumbers: number;
   jobsToRun: undefined | string[];
   mmsPerSecond: number;
   mmsSurgeCount: number;
@@ -54,6 +55,7 @@ const env = cleanEnv(process.env, {
   MAX_POOL_SIZE: num({ default: 20, devDefault: 50 }),
   MIN_POOL_SIZE: num({ default: 1 }),
   MIN_SUITABLE_NUMBERS: num({ default: 50 }),
+  SENDING_LOCATION_MIN_CALLING_NUMBERS: num({ default: 1 }),
   MMS_PER_SECOND: num({ default: 25 }),
   MMS_SURGE_COUNT: num({ default: 250 }),
   MODE: str({ default: 'DUAL' }),
@@ -101,6 +103,7 @@ const config: AppConfig = {
   maxPoolSize: env.MAX_POOL_SIZE,
   minPoolSize: env.MIN_POOL_SIZE,
   minSuitableNumbers: env.MIN_SUITABLE_NUMBERS,
+  sendingLocationMinCallingNumbers: env.SENDING_LOCATION_MIN_CALLING_NUMBERS,
   mmsPerSecond: env.MMS_SURGE_COUNT,
   mmsSurgeCount: env.MMS_SURGE_COUNT,
   mode: env.MODE,

--- a/src/lib/process-call.ts
+++ b/src/lib/process-call.ts
@@ -1,0 +1,59 @@
+import { PoolOrPoolClient } from '../db';
+import { chooseAreaCodeForSendingLocation } from './process-message';
+
+export const getCallingNumberForSendingLocation = async (
+  client: PoolOrPoolClient,
+  sendingLocationId: string,
+  dailyCallingLimit: number
+): Promise<string | null> => {
+  const {
+    rows: [row],
+  } = await client.query<{ phone_number: string | null }>(
+    `select phone_number
+     from sms.get_available_calling_numbers($1, $2)
+     order by priority asc, call_count asc
+     limit 1`,
+    [sendingLocationId, dailyCallingLimit]
+  );
+  return row?.phone_number ?? null;
+};
+
+export const countAvailableCallingNumbers = async (
+  client: PoolOrPoolClient,
+  sendingLocationId: string,
+  dailyCallingLimit: number
+): Promise<number> => {
+  const {
+    rows: [{ count }],
+  } = await client.query<{ count: string }>(
+    'select count(*) from sms.get_available_calling_numbers($1, $2)',
+    [sendingLocationId, dailyCallingLimit]
+  );
+  return parseInt(count, 10);
+};
+
+export const requestCallingNumber = async (
+  client: PoolOrPoolClient,
+  sendingLocationId: string
+): Promise<void> => {
+  const { rowCount: pendingCount } = await client.query(
+    `select 1 from sms.phone_number_requests
+     where sending_location_id = $1 and fulfilled_at is null and for_calling = true
+     limit 1`,
+    [sendingLocationId]
+  );
+
+  if ((pendingCount ?? 0) > 0) {
+    return;
+  }
+
+  const areaCode = await chooseAreaCodeForSendingLocation(
+    client,
+    sendingLocationId
+  );
+  await client.query(
+    `insert into sms.phone_number_requests (sending_location_id, area_code, for_calling)
+     values ($1, $2, true)`,
+    [sendingLocationId, areaCode]
+  );
+};


### PR DESCRIPTION
# Call Phone Number Routing

## How a number is selected
Profiles opt into calling by setting `sms.profiles.daily_call_limit`. When a call routing request comes in, the system first checks for an existing sticky mapping for the contact. If one exists and the mapped number is still under its daily limit, it is reused directly. If the mapped number has hit its limit, the mapping is temporarily bypassed and the system falls through to fresh selection (the mapping is preserved and will be honored again tomorrow when the limit resets). (Note: sticky mapping logic from texting is reused - if the number has a call or text sent to it within the last 3 days, reuse that number).

For fresh selection, the system picks a sending location via the existing zip-code routing logic, then selects the least-used available number via `sms.get_available_calling_numbers`.

Available numbers are drawn from two pools, in priority order:

**Texting numbers** (sms.phone_numbers, priority 1) — existing numbers shared with SMS, preferred to avoid purchasing new numbers when capacity exists

**Dedicated calling numbers** (sms.calling_phone_numbers, priority 2) — a new table for numbers reserved exclusively for calling. A number is considered unavailable if has reached `daily_calling_limit` calls since midnight Pacific time (timezone borrowed from texting logic - it's the end of the day in the continental US). The selection picks the number with the fewest calls today within the highest-priority available pool.

## Pool management
Two automatic top-up triggers keep the pool from running dry:

Empty pool: if no number is available at request time, a purchase is initiated immediately and the caller receives a 503.

Low pool: after a call is successfully assigned, if the remaining available count is at or below `SENDING_LOCATION_MIN_CALLING_NUMBERS` (default: 1), a purchase is proactively triggered.
Purchases are idempotent — `requestCallingNumber` no-ops if an unfulfilled `for_calling` request already exists for the sending location.

## Fine Tuning
There are 2 ways we can adjust phone number pool mgmt:

Per profile: Change `daily_calling_limit` to allow more or less calls per number. Thinking to default to 75 per [source 1](https://documentation.spectrumvoip.com/caller-id/avoid-having-your-number-flagged-as-spam-likely#:~:text=Control%20Call%20Volume.) and [source 2](https://readymode.com/avoid-being-flagged-as-spam-in-outbound-calls/#:~:text=2.%20Manage%20Your%20Call%20Volume%20and%20Frequency). And can monitor reputation score from Telnyx and adjust over time.

Global:  Increase `SENDING_LOCATION_MIN_CALLING_NUMBERS` (defaults to 1). If 1 number available at a time isn't enough to keep up with dialing volume, this would help have more available as backup


